### PR TITLE
Update SpongeGradle to 0.8.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.spongepowered.plugin' version '0.8.1'
+    id 'org.spongepowered.plugin' version '0.8.2'
     id 'com.github.johnrengelman.shadow' version '2.0.4'
 }
 


### PR DESCRIPTION
SpongeGradle 0.8.1 contains a bug that will sometimes not write the metadata
to the `mcmod.info` if the class files are up to date. This causes the Sponge
API version not to be visible on Ore.

I'd also recommended explicitly putting a dependency on SpongeForge in your
`@Plugin`, as the project will be given a SpongeForge tag. This will better
communicate to users what platform your plugin can be used on.